### PR TITLE
Update dynamicKistlerAlphaContactAngleFvPatchScalarField.C

### DIFF
--- a/interThermalPhaseFoam/Libraries/DynamicKistlerContactAngle/dynamicKistlerAlphaContactAngle/dynamicKistlerAlphaContactAngleFvPatchScalarField.C
+++ b/interThermalPhaseFoam/Libraries/DynamicKistlerContactAngle/dynamicKistlerAlphaContactAngle/dynamicKistlerAlphaContactAngleFvPatchScalarField.C
@@ -214,7 +214,7 @@ tmp<scalarField> dynamicKistlerAlphaContactAngleFvPatchScalarField::theta
         }
         else if (uwall[pfacei] > 0.0)
         {
-            thetaDp[pfacei] = HoffmanFunction(   Ca[pfacei]
+            thetaDp[pfacei] = HoffmanFunction(   -Ca[pfacei]
                                                + InvHoffFuncThetaRroot);
         }
     }


### PR DESCRIPTION
Respected Sir,

While implementing the contact angle model, the capillary number is defined to be always positive. 
To show the effect of receding dynamic contact angle , the capillary number in the kistler's model should be negative. So, I propose to change the sign of capillary number in line 217.

Cheers,
Manohar